### PR TITLE
ShiftForm日付フォーム修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,6 +1175,14 @@
         "@date-io/core": "^1.3.13"
       }
     },
+    "@date-io/moment": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-1.3.13.tgz",
+      "integrity": "sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==",
+      "requires": {
+        "@date-io/core": "^1.3.13"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -10809,6 +10817,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
+    "@date-io/moment": "^1.3.13",
     "@material-ui/core": "^4.11.3",
     "@material-ui/data-grid": "^4.0.0-alpha.24",
     "@material-ui/icons": "^4.11.2",
@@ -22,6 +23,7 @@
     "axios": "^0.21.1",
     "date-fns": "^2.20.0",
     "material-ui-flat-pagination": "^4.1.1",
+    "moment": "^2.29.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.3",

--- a/src/features/shift/ShiftForm.tsx
+++ b/src/features/shift/ShiftForm.tsx
@@ -7,8 +7,6 @@ import {
   FormControl,
   Select,
   Button,
-  Fab,
-  Modal,
 } from "@material-ui/core";
 import SaveIcon from "@material-ui/icons/Save";
 import AddIcon from "@material-ui/icons/Add";
@@ -17,6 +15,7 @@ import DateFnsUtils from "@date-io/date-fns";
 import { DatePicker } from "@material-ui/pickers";
 import jaLocale from "date-fns/locale/ja";
 import format from "date-fns/format";
+import moment, { Moment } from "moment";
 
 import { useSelector, useDispatch } from "react-redux";
 import {
@@ -64,18 +63,23 @@ const ShiftForm: React.FC = () => {
   const staffUsers = useSelector(selectStaff);
   const editedShift = useSelector(selectEditedShift);
 
-  const [inputText, setInputText] = useState("");
-
-  const [date, setDate] = React.useState<Date | null>(new Date());
+  const handleDateChange = (date: Date | null) => {
+    if (date !== null) {
+      const momentDate: Moment = moment(new Date(date));
+      dispatch(
+        editShift({
+          ...editedShift,
+          shift_date: momentDate.format("YYYY-MM-DD"),
+        })
+      );
+    }
+  };
 
   const isDisabled =
     editedShift.shift_date.length === 0 ||
     editedShift.shift_start.length === 0 ||
-    editedShift.shift_end.length === 0;
-
-  const handleInputTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputText(e.target.value);
-  };
+    editedShift.shift_end.length === 0 ||
+    editedShift.staff === 0;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value: string = e.target.value;
@@ -101,13 +105,43 @@ const ShiftForm: React.FC = () => {
       <h2>{editedShift.id ? "シフト更新" : "新規シフト"}</h2>
       <form>
         <DatePicker
+          name="shift_date"
           label="日付"
-          value={date}
-          onChange={setDate}
+          value={editedShift.shift_date === "" ? null : editedShift.shift_date}
+          onChange={handleDateChange}
           format="yyyy/MM/dd"
           animateYearScrolling
+          InputLabelProps={{
+            shrink: true,
+          }}
           okLabel="決定"
           cancelLabel="キャンセル"
+        />
+        <TextField
+          name="shift_start"
+          label="時間"
+          type="time"
+          value={editedShift.shift_start}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          inputProps={{
+            step: 300,
+          }}
+          onChange={handleInputChange}
+        />
+        <TextField
+          name="shift_end"
+          label=""
+          type="time"
+          value={editedShift.shift_end}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          inputProps={{
+            step: 300,
+          }}
+          onChange={handleInputChange}
         />
         <FormControl className={classes.field}>
           <InputLabel>従業員名</InputLabel>
@@ -119,6 +153,32 @@ const ShiftForm: React.FC = () => {
             {staffOptions}
           </Select>
         </FormControl>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          className={classes.button}
+          startIcon={<SaveIcon />}
+          disabled={isDisabled}
+          onClick={
+            editedShift.id !== 0
+              ? () => dispatch(fetchAsyncUpdateShift(editedShift))
+              : () => dispatch(fetchAsyncCreateShift(editedShift))
+          }
+        >
+          {editedShift.id !== 0 ? "更新" : "保存"}
+        </Button>
+        <Button
+          variant="contained"
+          color="default"
+          size="small"
+          onClick={() => {
+            dispatch(editShift(initialState.editedShift));
+            dispatch(selectShift(initialState.selectedShift));
+          }}
+        >
+          キャンセル
+        </Button>
       </form>
     </MuiPickersUtilsProvider>
   );

--- a/src/features/shift/shiftSlice.ts
+++ b/src/features/shift/shiftSlice.ts
@@ -1,13 +1,7 @@
 import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
 import { RootState } from "../../app/store";
 import axios from "axios";
-import {
-  READ_SHIFT,
-  POST_SHIFT,
-  READ_STAFF,
-  POST_STAFF,
-  SHIFT_STATE,
-} from "../types";
+import { READ_SHIFT, POST_SHIFT, SHIFT_STATE } from "../types";
 
 export const fetchAsyncGetShifts = createAsyncThunk(
   "shift/getShift",


### PR DESCRIPTION
## 概要
日付を選んだ際、editedShiftにセットされる値をYYYY-MM-DDの形式(HH:mm:ss:SSSを排除)にした。

## つまづいていた箇所
Material-UI Pickersで日付を選択しても表示がされなかった

## 解決方法
`type=data`を消したら直った...

## 参考
[Material-UI Pickers×Moment.jsをReact(TypeScript)で使う](https://qiita.com/natuuu0831/items/93d364884740303aa052)