### PR TITLE
新規シフト追加ボタンの設置・週カレンダー表示

### DIFF
--- a/src/features/shift/Shift.tsx
+++ b/src/features/shift/Shift.tsx
@@ -1,10 +1,20 @@
 import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+
 import ShiftForm from "./ShiftForm";
+import ShiftList from "./ShiftList";
+import ShiftDisplay from "./ShiftDisplay";
+import { selectEditedShift } from "./shiftSlice";
+
+import { AppDispatch } from "../../app/store";
 
 const Shift: React.FC = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const editedShift = useSelector(selectEditedShift);
   return (
     <>
-      <ShiftForm />
+      <ShiftList />
+      {editedShift.staff ? <ShiftForm /> : <ShiftDisplay />}
     </>
   );
 };

--- a/src/features/shift/ShiftForm.tsx
+++ b/src/features/shift/ShiftForm.tsx
@@ -79,7 +79,7 @@ const ShiftForm: React.FC = () => {
     editedShift.shift_date.length === 0 ||
     editedShift.shift_start.length === 0 ||
     editedShift.shift_end.length === 0 ||
-    editedShift.staff === 0;
+    editedShift.staff === 1;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value: string = e.target.value;

--- a/src/features/shift/ShiftList.tsx
+++ b/src/features/shift/ShiftList.tsx
@@ -5,6 +5,13 @@ import { makeStyles, Theme } from "@material-ui/core/styles";
 import AddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
 import { Button } from "@material-ui/core";
 
+import format from "date-fns/format";
+import getDate from "date-fns/getDate";
+import getDay from "date-fns/getDay";
+import startOfWeek from "date-fns/startOfWeek";
+import endOfWeek from "date-fns/endOfWeek";
+import eachDayOfInterval from "date-fns/eachDayOfInterval";
+
 import { selectShifts, editShift, selectShift } from "./shiftSlice";
 import { AppDispatch } from "../../app/store";
 import { initialState } from "./shiftSlice";
@@ -21,10 +28,32 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const getCalendar = (date: Date) => {
+  const startDate: Date = startOfWeek(date);
+  const endDate: Date = endOfWeek(date);
+  return eachDayOfInterval({
+    start: startDate.setDate(startDate.getDate() + 1),
+    end: endDate.setDate(endDate.getDate() + 1),
+  });
+};
+
 const ShiftList: React.FC = () => {
   const classes = useStyles();
   const dispatch: AppDispatch = useDispatch();
   const shifts = useSelector(selectShifts);
+
+  const days = [
+    { en: "mon", ja: "月" },
+    { en: "tue", ja: "火" },
+    { en: "wed", ja: "水" },
+    { en: "thu", ja: "木" },
+    { en: "fri", ja: "金" },
+    { en: "sat", ja: "土" },
+    { en: "sun", ja: "日" },
+  ];
+
+  const targetDate = new Date();
+  const calendar = getCalendar(targetDate);
 
   const [state, setState] = useState<SHIFT_PAGE_STATE>({
     rows: shifts,
@@ -62,6 +91,17 @@ const ShiftList: React.FC = () => {
       >
         新規シフト追加
       </Button>
+      <h2>{format(targetDate, "y年M月")}</h2>
+      <table>
+        <tbody>
+          {calendar.map((date, i) => (
+            <tr key={getDate(date)}>
+              <th key={getDay(date)}>{days[i].ja}</th>
+              <th key={getDate(date)}>{getDate(date)}</th>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </>
   );
 };

--- a/src/features/shift/ShiftList.tsx
+++ b/src/features/shift/ShiftList.tsx
@@ -1,7 +1,69 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import { makeStyles, Theme } from "@material-ui/core/styles";
+import AddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
+import { Button } from "@material-ui/core";
+
+import { selectShifts, editShift, selectShift } from "./shiftSlice";
+import { AppDispatch } from "../../app/store";
+import { initialState } from "./shiftSlice";
+import { SHIFT_PAGE_STATE } from "../types";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  button: {
+    margin: theme.spacing(3),
+  },
+  small: {
+    margin: "auto",
+    width: theme.spacing(3),
+    height: theme.spacing(3),
+  },
+}));
 
 const ShiftList: React.FC = () => {
-  return <div></div>;
+  const classes = useStyles();
+  const dispatch: AppDispatch = useDispatch();
+  const shifts = useSelector(selectShifts);
+
+  const [state, setState] = useState<SHIFT_PAGE_STATE>({
+    rows: shifts,
+    offset: 0,
+    parPage: 10,
+  });
+
+  useEffect(() => {
+    setState((state) => ({
+      ...state,
+      rows: shifts,
+    }));
+  }, [shifts]);
+
+  return (
+    <>
+      <Button
+        className={classes.button}
+        variant="contained"
+        color="secondary"
+        size="small"
+        startIcon={<AddCircleOutlineIcon />}
+        onClick={() => {
+          dispatch(
+            editShift({
+              id: 0,
+              shift_date: "",
+              shift_start: "",
+              shift_end: "",
+              staff: 1,
+            })
+          );
+          dispatch(selectShift(initialState.selectedShift));
+        }}
+      >
+        新規シフト追加
+      </Button>
+    </>
+  );
 };
 
 export default ShiftList;

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -58,6 +58,12 @@ export interface SHIFT_STATE {
   editedShift: POST_SHIFT;
   selectedShift: READ_SHIFT;
 }
+/*ShiftList.tsx*/
+export interface SHIFT_PAGE_STATE {
+  rows: READ_SHIFT[];
+  offset: number;
+  parPage: number;
+}
 /*staffSlice.ts*/
 export interface READ_STAFF {
   id: number;


### PR DESCRIPTION
## 概要
・新規シフト追加ボタンの設置
・週カレンダー表示
週カレンダー表示の仕方に苦戦した。

## 参考
[date-fnsを使用してカレンダー作成する(その1: 今月のカレンダーを表示する)](http://yucatio.hatenablog.com/entry/2019/12/23/172547)
[startofweek()とendofweek()を月曜始まりにする](https://www.javaer101.com/ja/article/52250953.html)
[Qiita JSカレンダー](https://qiita.com/kan_dai/items/b1850750b883f83b9bee)
[Qiita JSカレンダー](https://qiita.com/shingorow/items/6085693cb039f073c5e2)