### PR TITLE
シフト表バグ修正

### DIFF
--- a/src/Default.tsx
+++ b/src/Default.tsx
@@ -20,6 +20,10 @@ import {
 } from "./features/auth/authSlice";
 
 import { fetchAsyncGetStaff } from "./features/staff/staffSlice";
+import {
+  selectDateState,
+  fetchAsyncGetShifts,
+} from "./features/shift/shiftSlice";
 
 import { AppDispatch } from "./app/store";
 
@@ -108,11 +112,14 @@ const Default: React.FC = () => {
     fileInput?.click();
   };
 
+  const DateState = useSelector(selectDateState);
+
   useEffect(() => {
     const fetchBootLoader = async () => {
       await dispatch(fetchAsyncGetMyProf());
       await dispatch(fetchAsyncGetProfs());
       await dispatch(fetchAsyncGetStaff());
+      await dispatch(fetchAsyncGetShifts(DateState));
     };
     fetchBootLoader();
   }, [dispatch]);

--- a/src/features/shift/Shift.tsx
+++ b/src/features/shift/Shift.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import ShiftForm from "./ShiftForm";
 import ShiftList from "./ShiftList";
 import ShiftDisplay from "./ShiftDisplay";
 import { selectEditedShift } from "./shiftSlice";
@@ -11,10 +10,10 @@ import { AppDispatch } from "../../app/store";
 const Shift: React.FC = () => {
   const dispatch: AppDispatch = useDispatch();
   const editedShift = useSelector(selectEditedShift);
+
   return (
     <>
       <ShiftList />
-      {editedShift.lane ? <ShiftForm /> : <ShiftDisplay />}
     </>
   );
 };

--- a/src/features/shift/ShiftForm.tsx
+++ b/src/features/shift/ShiftForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "@material-ui/core";
 import SaveIcon from "@material-ui/icons/Save";
 import AddIcon from "@material-ui/icons/Add";
+import DeleteOutlineOutlinedIcon from "@material-ui/icons/DeleteOutlineOutlined";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import { DatePicker } from "@material-ui/pickers";
@@ -21,6 +22,7 @@ import { useSelector, useDispatch } from "react-redux";
 import {
   fetchAsyncCreateShift,
   fetchAsyncUpdateShift,
+  fetchAsyncDeleteShift,
   selectEditedShift,
   editShift,
   selectShift,
@@ -187,6 +189,21 @@ const ShiftForm: React.FC = () => {
         >
           {editedShift.id !== 0 ? "更新" : "保存"}
         </Button>
+        {editedShift.id !== 0 && (
+          <Button
+            variant="contained"
+            color="default"
+            size="small"
+            className={classes.button}
+            startIcon={<DeleteOutlineOutlinedIcon />}
+            onClick={() => {
+              dispatch(fetchAsyncDeleteShift(editedShift.id));
+              dispatch(editShift(initialState.editedShift));
+            }}
+          >
+            削除
+          </Button>
+        )}
         <Button
           variant="contained"
           color="default"

--- a/src/features/shift/ShiftForm.tsx
+++ b/src/features/shift/ShiftForm.tsx
@@ -107,6 +107,15 @@ const ShiftForm: React.FC = () => {
     </MenuItem>
   ));
 
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
     <MuiPickersUtilsProvider utils={ExtendedUtils} locale={jaLocale}>
       <h2>{editedShift.id ? "シフト更新" : "新規シフト"}</h2>
@@ -209,6 +218,7 @@ const ShiftForm: React.FC = () => {
           color="default"
           size="small"
           onClick={() => {
+            handleClose();
             dispatch(editShift(initialState.editedShift));
             dispatch(selectShift(initialState.selectedShift));
           }}

--- a/src/features/shift/shiftSlice.ts
+++ b/src/features/shift/shiftSlice.ts
@@ -4,15 +4,19 @@ import axios from "axios";
 import { READ_SHIFT, POST_SHIFT, SHIFT_STATE, DATE_STATE } from "../types";
 
 import format from "date-fns/format";
+import startOfWeek from "date-fns/startOfWeek";
+import endOfWeek from "date-fns/endOfWeek";
+import addWeeks from "date-fns/addWeeks";
+import subWeeks from "date-fns/subWeeks";
 
 export const fetchAsyncGetShifts = createAsyncThunk(
   "shift/getShift",
   async (date: DATE_STATE) => {
     const res = await axios.get<READ_SHIFT[]>(
       `${process.env.REACT_APP_API_URL}/api/shift/?shift_date_after=${format(
-        date.sDate,
+        date.startDate,
         "y-M-d"
-      )}&shift_date_before=${format(date.eDate, "y-M-d")}`,
+      )}&shift_date_before=${format(date.endDate, "y-M-d")}`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -108,6 +112,12 @@ export const initialState: SHIFT_STATE = {
     created_at: "",
     updated_at: "",
   },
+  dateState: {
+    startDate: startOfWeek(new Date()).setDate(
+      startOfWeek(new Date()).getDate() + 1
+    ),
+    endDate: endOfWeek(new Date()).setDate(endOfWeek(new Date()).getDate() + 1),
+  },
 };
 export const shiftSlice = createSlice({
   name: "shift",
@@ -118,6 +128,21 @@ export const shiftSlice = createSlice({
     },
     selectShift(state, action: PayloadAction<READ_SHIFT>) {
       state.selectedShift = action.payload;
+    },
+    resetDateState(state, action: PayloadAction<DATE_STATE>) {
+      state.dateState = action.payload;
+    },
+    lastWeeks: (state) => {
+      state.dateState.startDate = Number(
+        subWeeks(state.dateState.startDate, 1)
+      );
+      state.dateState.endDate = Number(subWeeks(state.dateState.endDate, 1));
+    },
+    afterWeeks: (state) => {
+      state.dateState.startDate = Number(
+        addWeeks(state.dateState.startDate, 1)
+      );
+      state.dateState.endDate = Number(addWeeks(state.dateState.endDate, 1));
     },
   },
   extraReducers: (builder) => {
@@ -179,9 +204,16 @@ export const shiftSlice = createSlice({
   },
 });
 
-export const { editShift, selectShift } = shiftSlice.actions;
+export const {
+  editShift,
+  selectShift,
+  resetDateState,
+  lastWeeks,
+  afterWeeks,
+} = shiftSlice.actions;
 export const selectShifts = (state: RootState) => state.shift.shifts;
 export const selectEditedShift = (state: RootState) => state.shift.editedShift;
 export const selectSelectedShift = (state: RootState) =>
   state.shift.selectedShift;
+export const selectDateState = (state: RootState) => state.shift.dateState;
 export default shiftSlice.reducer;

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -55,20 +55,15 @@ export interface POST_SHIFT {
   lane: number;
   staff: number;
 }
+export interface DATE_STATE {
+  startDate: number;
+  endDate: number;
+}
 export interface SHIFT_STATE {
   shifts: READ_SHIFT[];
   editedShift: POST_SHIFT;
   selectedShift: READ_SHIFT;
-}
-export interface DATE_STATE {
-  sDate: number;
-  eDate: number;
-}
-/*ShiftList.tsx*/
-export interface SHIFT_PAGE_STATE {
-  rows: READ_SHIFT[];
-  offset: number;
-  parPage: number;
+  dateState: DATE_STATE;
 }
 /*staffSlice.ts*/
 export interface READ_STAFF {


### PR DESCRIPTION
## 概要
* 日付の移動(前の週、今週、次の週ボタンを押した時)に正しくカレンダーが表示されないのを修正
* 日付の移動したときに、シフトデータが一瞬しか表示されないのを修正
