### PR TITLE
buildされた時のjs等のPATHの問題対処

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_URL= http://127.0.0.1:8000

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "simpleshift24_front",
   "version": "0.1.0",
+  "homepage": ".",
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React Redux App</title>
+    <title>シンプルシフト24</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/features/shift/shiftSlice.ts
+++ b/src/features/shift/shiftSlice.ts
@@ -202,7 +202,7 @@ export const shiftSlice = createSlice({
       (state, action: PayloadAction<number>) => {
         return {
           ...state,
-          tasks: state.shifts.filter((s) => s.id !== action.payload),
+          shifts: state.shifts.filter((s) => s.id !== action.payload),
           editedTask: initialState.editedShift,
           selectedTask: initialState.selectedShift,
         };


### PR DESCRIPTION
## 概要
buildに時に画面に何も表示されずに真っ白になった。

## 原因・解決方法
PATHの設定がうまくいっていないのが原因だった。
package.jsonに、以下を追記したらうまくいった。
`"homepage": ".",`